### PR TITLE
Update image

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,7 @@ docker build --tag vscode-devcontainer .
 # Run docker image to test insides
 docker run -d --name localdevcontainer vscode-devcontainer
 docker exec -it localdevcontainer bash
+
+# Before releasing, make sure the image is built afresh without cached layers
+docker build --no-cache --tag vscode-devcontainer .
 ```


### PR DESCRIPTION
Change to Dockerfile:

1. Print binary path and version
2. Follow redirect when installing tflint
3. Install the current latest: terraform-docs, tfsec
4. Set PATH to hadolint (it's installed under `/root/.local/bin`)

Changes to README.md:
1. Document `docker build --no-cache` to get all newest versions installed

We can remove printing of binary paths and versions, but they make sure the expected software gets installed.